### PR TITLE
📝 Add note about GitHub team memberships

### DIFF
--- a/docs/runbooks/onboarding.md
+++ b/docs/runbooks/onboarding.md
@@ -18,7 +18,7 @@
     - Team name (e.g. Data Platform)
 
     - GitHub team name (used for access control)
-  
+
       - Note: If the team is a parent of other teams, child team's members will be included as part of the parent team's members,
         this is a quirk of <https://github.com/ministryofjustice/moj-terraform-scim-github>
 

--- a/docs/runbooks/onboarding.md
+++ b/docs/runbooks/onboarding.md
@@ -18,6 +18,9 @@
     - Team name (e.g. Data Platform)
 
     - GitHub team name (used for access control)
+  
+      - Note: If the team is a parent of other teams, child team's members will be included as part of the parent team's members,
+        this is a quirk of <https://github.com/ministryofjustice/moj-terraform-scim-github>
 
     - Account names
 


### PR DESCRIPTION
This pull request:

- Closes #9
- Adds a note to the onboarding runbook about GitHub team memberships

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>