### PR TITLE
🔥 Remove Terraform heading from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ This is the Ministry of Justice Observability Platform team's repository for doc
 
 ## Other Observability Platform repositories
 
-### Terraform modules
-
 | Name | Description |
 |:---:|:---:|
 | [`observability-platform-grafana-key-rotator`](https://github.com/ministryofjustice/observability-platform-grafana-key-rotator) | Observability Platform Grafana key rotator |


### PR DESCRIPTION
This pull request:

- Removes `Terraform modules` heading from README

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 