### PR TITLE
🔥 Remove `.lycheeignore`

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,0 @@
-https://user-guide.observability-platform.service.justice.gov.uk


### PR DESCRIPTION
This pull request:

- Removes `.lycheeignore` as it only container a reference to the now published user guide

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 