### PR TITLE
Disabling BIOME format and lint

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -35,3 +35,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_CSS: false
           VALIDATE_JSCPD: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false


### PR DESCRIPTION
The superlinter already check JSON files with JSON formatter and Prettier.
Disabling the BIOME that is not configured and is currently failing.